### PR TITLE
Add stress test and improve wifi parser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+.pytest_cache/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
 # Wifipentest
+
+This repository contains utilities and notes related to Wi-Fi security testing. All examples and code in this project are provided for educational and lawful testing purposes only. Do **not** run any of these tools against networks you do not own or have explicit permission to test.
+
+## Running Tests
+
+The project includes a small utility for parsing `iwconfig` output along with unit tests. You can run the tests with:
+
+```bash
+python -m pytest -q
+```
+
+You can also run a simple stress test that parses a large synthetic
+`iwconfig` output to check the parser's performance:
+
+```bash
+python -m wifipentest.stress_test
+```
+

--- a/tests/test_wifi_utils.py
+++ b/tests/test_wifi_utils.py
@@ -1,0 +1,20 @@
+from wifipentest.wifi_utils import parse_iwconfig_output
+
+
+def test_parse_iwconfig_output_single_interface():
+    sample_output = """\
+wlan0     IEEE 802.11  ESSID:"test"  
+          Mode:Managed  Frequency:2.437 GHz  Access Point: 00:11:22:33:44:55   
+    """
+    assert parse_iwconfig_output(sample_output) == ["wlan0"]
+
+
+def test_parse_iwconfig_output_multiple_interfaces():
+    sample_output = """\
+wlan0     IEEE 802.11  ESSID:"test1"  
+eth0      no wireless extensions.
+wlan1     IEEE 802.11  ESSID:"test2"  
+    """
+    assert parse_iwconfig_output(sample_output) == ["wlan0", "wlan1"]
+
+

--- a/tests/test_wifi_utils_stress.py
+++ b/tests/test_wifi_utils_stress.py
@@ -1,0 +1,9 @@
+from wifipentest.wifi_utils import parse_iwconfig_output
+
+
+def test_parse_iwconfig_output_large_output():
+    line = "wlan0     IEEE 802.11  ESSID:\"test\"\n"
+    sample_output = line * 1000
+    result = parse_iwconfig_output(sample_output)
+    assert len(result) == 1000
+    assert all(iface == "wlan0" for iface in result)

--- a/wifipentest/stress_test.py
+++ b/wifipentest/stress_test.py
@@ -1,0 +1,26 @@
+"""Simple stress test for ``parse_iwconfig_output``.
+
+This script generates a large synthetic ``iwconfig`` output and measures
+how quickly the parser can process it.
+"""
+
+import time
+
+from .wifi_utils import parse_iwconfig_output
+
+
+def generate_sample(repetitions: int = 1000) -> str:
+    line = "wlan0     IEEE 802.11  ESSID:\"test\"\n"
+    return line * repetitions
+
+
+def main() -> None:
+    sample = generate_sample()
+    start = time.perf_counter()
+    interfaces = parse_iwconfig_output(sample)
+    duration = time.perf_counter() - start
+    print(f"Parsed {len(interfaces)} entries in {duration:.4f} seconds")
+
+
+if __name__ == "__main__":
+    main()

--- a/wifipentest/wifi_utils.py
+++ b/wifipentest/wifi_utils.py
@@ -1,0 +1,41 @@
+"""Utility functions for working with wireless interface information."""
+
+import re
+from typing import List
+
+# precompile regex for better performance when parsing large outputs
+_INTERFACE_RE = re.compile(r"^(\S+)\s+.*IEEE\s+802\.11")
+
+
+def parse_iwconfig_output(output: str) -> List[str]:
+    """Parse output from the ``iwconfig`` command.
+
+    Parameters
+    ----------
+    output:
+        Raw output text from ``iwconfig``.
+
+    Returns
+    -------
+    list of str
+        Names of wireless interfaces present in the output.
+    """
+    interfaces = []
+    for line in output.splitlines():
+        # Lines that start with an interface name often contain 'IEEE 802.11'
+        match = _INTERFACE_RE.match(line)
+        if match:
+            interfaces.append(match.group(1))
+    return interfaces
+
+
+if __name__ == "__main__":
+    import subprocess
+    try:
+        result = subprocess.run(["iwconfig"], capture_output=True, text=True, check=True)
+        for iface in parse_iwconfig_output(result.stdout):
+            print(iface)
+    except FileNotFoundError:
+        print("iwconfig command not found. Ensure wireless tools are installed.")
+    except subprocess.CalledProcessError as exc:
+        print(f"Error running iwconfig: {exc}")


### PR DESCRIPTION
## Summary
- compile regex once for better parsing performance
- add a stress test script and unit test
- ignore caches via `.gitignore`
- document stress test and fix test instructions

## Testing
- `python -m pytest -q`
- `python -m wifipentest.stress_test`


------
https://chatgpt.com/codex/tasks/task_e_68609a8541e883258c13c7bd2d0aadf2