### PR TITLE
Enhance iwconfig parser to return mode

### DIFF
--- a/tests/test_wifi_utils.py
+++ b/tests/test_wifi_utils.py
@@ -6,7 +6,7 @@ def test_parse_iwconfig_output_single_interface():
 wlan0     IEEE 802.11  ESSID:"test"  
           Mode:Managed  Frequency:2.437 GHz  Access Point: 00:11:22:33:44:55   
     """
-    assert parse_iwconfig_output(sample_output) == ["wlan0"]
+    assert parse_iwconfig_output(sample_output) == [("wlan0", "Managed")]
 
 
 def test_parse_iwconfig_output_multiple_interfaces():
@@ -15,6 +15,6 @@ wlan0     IEEE 802.11  ESSID:"test1"
 eth0      no wireless extensions.
 wlan1     IEEE 802.11  ESSID:"test2"  
     """
-    assert parse_iwconfig_output(sample_output) == ["wlan0", "wlan1"]
+    assert parse_iwconfig_output(sample_output) == [("wlan0", None), ("wlan1", None)]
 
 

--- a/tests/test_wifi_utils_stress.py
+++ b/tests/test_wifi_utils_stress.py
@@ -6,4 +6,4 @@ def test_parse_iwconfig_output_large_output():
     sample_output = line * 1000
     result = parse_iwconfig_output(sample_output)
     assert len(result) == 1000
-    assert all(iface == "wlan0" for iface in result)
+    assert all(item == ("wlan0", None) for item in result)

--- a/wifipentest/wifi_utils.py
+++ b/wifipentest/wifi_utils.py
@@ -1,14 +1,15 @@
 """Utility functions for working with wireless interface information."""
 
 import re
-from typing import List
+from typing import List, Optional, Tuple
 
 # precompile regex for better performance when parsing large outputs
 _INTERFACE_RE = re.compile(r"^(\S+)\s+.*IEEE\s+802\.11")
 
 
-def parse_iwconfig_output(output: str) -> List[str]:
-    """Parse output from the ``iwconfig`` command.
+def parse_iwconfig_output(output: str) -> List[Tuple[str, Optional[str]]]:
+    """Parse output from the ``iwconfig`` command and return interface
+    names along with their operating modes.
 
     Parameters
     ----------
@@ -17,15 +18,32 @@ def parse_iwconfig_output(output: str) -> List[str]:
 
     Returns
     -------
-    list of str
-        Names of wireless interfaces present in the output.
+    list of tuple(str, Optional[str])
+        A list of ``(interface, mode)`` tuples. ``mode`` may be ``None`` if it
+        cannot be determined from the output.
     """
     interfaces = []
-    for line in output.splitlines():
-        # Lines that start with an interface name often contain 'IEEE 802.11'
+    lines = output.splitlines()
+    i = 0
+    while i < len(lines):
+        line = lines[i]
         match = _INTERFACE_RE.match(line)
         if match:
-            interfaces.append(match.group(1))
+            iface = match.group(1)
+            mode = None
+            # Look for a ``Mode:`` field on this line or subsequent lines until
+            # another interface definition is encountered.
+            mode_match = re.search(r"Mode:(\S+)", line)
+            j = i + 1
+            while mode is None and j < len(lines) and not _INTERFACE_RE.match(lines[j]):
+                if mode_match is None:
+                    mode_match = re.search(r"Mode:(\S+)", lines[j])
+                j += 1
+            if mode_match:
+                mode = mode_match.group(1)
+            interfaces.append((iface, mode))
+            i = j - 1
+        i += 1
     return interfaces
 
 
@@ -33,8 +51,11 @@ if __name__ == "__main__":
     import subprocess
     try:
         result = subprocess.run(["iwconfig"], capture_output=True, text=True, check=True)
-        for iface in parse_iwconfig_output(result.stdout):
-            print(iface)
+        for iface, mode in parse_iwconfig_output(result.stdout):
+            if mode:
+                print(f"{iface} ({mode})")
+            else:
+                print(iface)
     except FileNotFoundError:
         print("iwconfig command not found. Ensure wireless tools are installed.")
     except subprocess.CalledProcessError as exc:


### PR DESCRIPTION
## Summary
- parse mode information from iwconfig output
- adapt CLI helper and stress test to new tuple output
- update unit tests for new return format

## Testing
- `python -m pytest -q`
- `python -m wifipentest.stress_test`


------
https://chatgpt.com/codex/tasks/task_e_68611d889e688325bef0221cd74ca669